### PR TITLE
Chore: Set Dockerfile to run in prod environment [NOID]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ COPY --from=stage1 /app/main .
 COPY --from=stage1 /app/config ./root/config
 
 # If you have to run in develop mode, copy the env file
-COPY --from=stage1 /app/.env.development ./
+# COPY --from=stage1 /app/.env.development ./
 
 # Expose port 8080
 EXPOSE 8080
 
 # Command to run the application
-CMD ["./main", "-e", "development"]
+CMD ["./main", "-e", "production"]


### PR DESCRIPTION
## 📝 Description

This PR updates the Dockerfile to run the application in **production** mode instead of **development**.

### 🔧 Changes:
- Commented out the line that copies the `.env.development` file
- Changed the start command from `-e development` to `-e production`

---

## 📸 Screenshots (if applicable)

_Not applicable – no visual/UI changes._

---

## 🧪 How to Test

1. Build the Docker image:
   ```bash
   docker build -t my-app .
2. Run the container: 
   ```bash
   docker run -p 8080:8080 my-app
3. Check that the app starts in production mode and everything works as expected

---

## ✅ Checklist
 - [X] Dockerfile updated
 - [X] Manual test done with production flag
 - [ ] No breaking changes introduced

---

## 📎 Related Issues / Tasks

N/A