### PR TITLE
Feat: Use Sendgrid to send portfolio messages to my email [NOID]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
+# Project Config
 PORT=
 
+# Database config
 MONGO_URI=
 MONGO_DATABASE=
+
+# Email provider config
+SENDGRID_API_KEY=

--- a/api/emails/emails.go
+++ b/api/emails/emails.go
@@ -1,0 +1,7 @@
+package emails
+
+type SendPortfolioMessage struct {
+	Name    string `json:"name" bson:"name" validate:"required"`
+	Email   string `json:"email" bson:"email" validate:"required,email"`
+	Message string `json:"message" bson:"message" validate:"required,min=10"`
+}

--- a/api/emails/emails_controller.go
+++ b/api/emails/emails_controller.go
@@ -1,6 +1,7 @@
 package emails
 
 import (
+	"fmt"
 	"net/http"
 	response "portfolio/api/utils"
 
@@ -19,9 +20,12 @@ func NewEmailsController(
 	}
 }
 
-func (ctx *EmailsController) Send(c *gin.Context) {
-	message, err := ctx.emailsService.Send()
+func (ctx *EmailsController) SendPortfolioMessage(c *gin.Context) {
+	data := c.MustGet("payload").(*SendPortfolioMessage)
+
+	message, err := ctx.emailsService.SendPortfolioMessage(*data)
 	if err != nil {
+		fmt.Println(err.Error())
 		response.Error(c, "Error to send email.")
 		return
 	}

--- a/api/emails/emails_service.go
+++ b/api/emails/emails_service.go
@@ -1,6 +1,11 @@
 package emails
 
 import (
+	"errors"
+	"portfolio/api/config"
+
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -14,6 +19,25 @@ func NewEmailsService(mongoDB *mongo.Database) *EmailsService {
 	}
 }
 
-func (ctx *EmailsService) Send() (string, error) {
-	return "", nil
+func (ctx *EmailsService) SendPortfolioMessage(data SendPortfolioMessage) (string, error) {
+	from := mail.NewEmail("Portfolio Message", "no.reply@takedi.com")
+	subject := "New message from portfolio 🎉"
+	to := mail.NewEmail("Vinicius Takedi", "viniciustakedi7@gmail.com")
+
+	plainTextContent := getPortfolioMessagePlainText(data)
+	htmlContent := getPortfolioMessageHTML(data)
+
+	message := mail.NewSingleEmail(from, subject, to, plainTextContent, htmlContent)
+	client := sendgrid.NewSendClient(config.GetEnv("SENDGRID_API_KEY"))
+
+	response, err := client.Send(message)
+	if err != nil {
+		return "", err
+	}
+
+	if response.StatusCode != 202 {
+		return "", errors.New(response.Body)
+	}
+
+	return "Email sent successfully!", nil
 }

--- a/api/emails/emails_templates.go
+++ b/api/emails/emails_templates.go
@@ -1,0 +1,23 @@
+package emails
+
+import "strings"
+
+func getPortfolioMessageHTML(data SendPortfolioMessage) string {
+	html := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><title>New portfolio message!</title><style>body {font-family: Arial, sans-serif;background-color: #f9f9f9;padding: 20px;margin: 0;}.email-container {max-width: 500px;margin: 0 auto;background-color: #ffffff;border-radius: 10px;padding: 40px 20px;text-align: center;box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);}.emoji {font-size: 48px;margin-bottom: 20px;}h1 {font-size: 22px;margin-bottom: 10px;}p {font-size: 16px;color: #555555;margin: 10px 0;}a.button {display: inline-block;margin-top: 20px;padding: 12px 24px;background-color: #007bff;color: #ffffff;text-decoration: none;border-radius: 6px;font-weight: bold;}.footer {font-size: 12px;color: #999999;margin-top: 30px;}</style></head><body><div class="email-container"><div class="emoji">🥳</div><h1>{{sender_name}} sent a message to you!</h1><p>To reply {{sender_name}} use your professional email <strong>contact@takedi.com</strong> and send a message to <strong>{{sender_email}}</strong>.</p><p style="margin-top: 30px;background-color: #f1f1f1;border-radius: 8px;padding: 15px;">"{{sender_message}}"</p><a href="https://takedi.com" class="button">Click here to go to portfolio</a><p class="footer">This email was sent automatically to Vinicius Takedi. If you received this by mistake, please disregard it. Thank you very much!</p></div></body></html>`
+
+	html = strings.Replace(html, "{{sender_name}}", data.Name, -1)
+	html = strings.Replace(html, "{{sender_email}}", data.Email, -1)
+	html = strings.Replace(html, "{{sender_message}}", data.Message, -1)
+
+	return html
+}
+
+func getPortfolioMessagePlainText(data SendPortfolioMessage) string {
+	plaintext := `🥳 New portfolio message! {{sender_name}} sent a message to you! To reply {{sender_name}}, use your professional email contact@takedi.com and send a message to {{sender_email}}. Message: "{{sender_message}}" Click here to go to portfolio: https://takedi.com --- This email was sent automatically to Vinicius Takedi. If you received this by mistake, please disregard it. Thank you very much!`
+
+	plaintext = strings.Replace(plaintext, "{{sender_name}}", data.Name, -1)
+	plaintext = strings.Replace(plaintext, "{{sender_email}}", data.Email, -1)
+	plaintext = strings.Replace(plaintext, "{{sender_message}}", data.Message, -1)
+
+	return plaintext
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.16.0+incompatible // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,10 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.16.0+incompatible h1:i8eE6IMkiCy7vusSdacHHSBUpXyTcTXy/Rl9N9aZ/Qw=
+github.com/sendgrid/sendgrid-go v3.16.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/middlewares/validator.go
+++ b/middlewares/validator.go
@@ -1,0 +1,38 @@
+package middlewares
+
+import (
+	response "portfolio/api/utils"
+	"reflect"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+)
+
+func PayloadValidator(payload interface{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		payloadInstance := reflect.New(reflect.TypeOf(payload).Elem()).Interface()
+
+		if err := c.ShouldBindJSON(payloadInstance); err != nil {
+			response.Error(c, "Error to process JSON: "+err.Error())
+			c.Abort()
+			return
+		}
+
+		validate := validator.New()
+
+		if err := validate.Struct(payloadInstance); err != nil {
+			var errors []string
+			for _, fieldError := range err.(validator.ValidationErrors) {
+				errors = append(errors, fieldError.Error())
+			}
+
+			response.Error(c, "Validation failed: "+strings.Join(errors, ", "))
+			c.Abort()
+			return
+		}
+
+		c.Set("payload", payloadInstance)
+		c.Next()
+	}
+}

--- a/router/email_routes.go
+++ b/router/email_routes.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"portfolio/api/api/emails"
+	"portfolio/api/middlewares"
 
 	"github.com/gin-gonic/gin"
 )
@@ -17,9 +18,9 @@ func RegisterEmailsRoutes(router *gin.RouterGroup) {
 	}{
 		{
 			method:      "POST",
-			route:       "/email/send",
-			handler:     emailsController.Send,
-			middlewares: []gin.HandlerFunc{},
+			route:       "/email/send/portfolio-message",
+			handler:     emailsController.SendPortfolioMessage,
+			middlewares: []gin.HandlerFunc{middlewares.PayloadValidator(&emails.SendPortfolioMessage{})},
 		},
 	}
 

--- a/router/router.go
+++ b/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/gin-gonic/gin"
@@ -19,13 +20,14 @@ func NewRouter(environment string) *gin.Engine {
 
 	router.Use(func(c *gin.Context) {
 		origin := c.GetHeader("Origin")
+
 		originsAllowed := []string{
 			"https://takedi.com",
 			"https://my-portfolio-git-v2-viniciustakedis-projects.vercel.app",
 		}
 
 		if environment == "development" {
-			originsAllowed = append(originsAllowed, "http://localhost:3000")
+			originsAllowed = append(originsAllowed, origin)
 		}
 
 		if slices.Contains(originsAllowed, origin) {

--- a/router/router.go
+++ b/router/router.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"fmt"
 	"slices"
 
 	"github.com/gin-gonic/gin"


### PR DESCRIPTION
## 📝 Description

This PR have the base code to send emails from my portfolio to my personal email account. I'm using Sendgrid and personal templates to send the messages.

### 🔧 Changes:
- New route to send emails from my portfolio.
- New function using Sendgrid PKG to send emails with my professional domain.
- New middleware to validate the request payload.
- Personalized email HTML & Plaintext templates to send emails.

---

## 📸 Screenshots (if applicable)
<img width="996" alt="Screenshot 2025-04-22 at 11 43 33" src="https://github.com/user-attachments/assets/5c5f1366-95ad-4727-b5d2-465fe2eeff9b" />

---

## ✅ Checklist
 - [X] Route to send emails from portfolio.
 - [X] Function to send emails by Sendgrid with my professional domain name.
 - [X] Middleware to validate request payload.
 - [X] Personalized templates to send email.
 - [X] No breaking changes introduced.

---

## 📎 Related Issues / Tasks

N/A