### PR TITLE
Feat: Add phrasal verbs on newsletter

### DIFF
--- a/api/emails/emails_controller.go
+++ b/api/emails/emails_controller.go
@@ -42,3 +42,13 @@ func (ctx *EmailsController) SendDailyWordNewsletter() error {
 
 	return nil
 }
+
+func (ctx *EmailsController) SendDailyPhrasalVerbNewsletter() error {
+	err := ctx.emailsService.SendDailyPhrasalVerbNewsletter()
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/api/emails/emails_service.go
+++ b/api/emails/emails_service.go
@@ -217,3 +217,170 @@ func (svc *EmailsService) SendDailyWordNewsletter() error {
 
 	return nil
 }
+
+func (svc *EmailsService) SendDailyPhrasalVerbNewsletter() error {
+	// 1 - Prepare context and IDs & Get word of the day
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	newsletterTypeID, err := primitive.ObjectIDFromHex("684cd13895298f80e21813a9")
+	if err != nil {
+		return fmt.Errorf("invalid newsletterTypeId: %w", err)
+	}
+
+	phrasalVerbColl := svc.mongoDB.Collection("dailywordnewsletterphrasalverbs")
+	filter := bson.M{"used": false}
+	update := bson.M{"$set": bson.M{"used": true}}
+	// return the *updated* document
+	opts := options.FindOneAndUpdate().
+		SetReturnDocument(options.After)
+
+	phrasalVerbRes := phrasalVerbColl.FindOneAndUpdate(ctx, filter, update, opts)
+	if err := phrasalVerbRes.Err(); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return fmt.Errorf("no unused words left")
+		}
+		return fmt.Errorf("findOneAndUpdate error: %w", err)
+	}
+
+	var phrasalVerb WordDB
+	if err := phrasalVerbRes.Decode(&phrasalVerb); err != nil {
+		return fmt.Errorf("decoding phrasalverb: %w", err)
+	}
+
+	// 2 - Load API keys
+	openAIKey := config.GetEnv("OPENAI_API_KEY")
+	if openAIKey == "" {
+		return errors.New("OPENAI_API_KEY not set")
+	}
+	sendGridKey := config.GetEnv("SENDGRID_API_KEY")
+	if sendGridKey == "" {
+		return errors.New("SENDGRID_API_KEY not set")
+	}
+
+	// 3 - Build OpenAI request
+	client := openai.NewClient(openAIKey)
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: `You are a dictionary assistant. Respond with JSON only, containing these fields: word (string), definition (string), usageTip (string), funFact (string), examples (array of strings), synonyms (array of strings), antonyms (array of strings).`,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: fmt.Sprintf("Provide detailed information for the phrasal verb %s", phrasalVerb.Name),
+			},
+		},
+		Temperature:      0.9,
+		TopP:             0.9,
+		PresencePenalty:  0.6,
+		FrequencyPenalty: 0.6,
+	}
+
+	// 4 -  Call with retries on 5xx
+	var chatResp openai.ChatCompletionResponse
+	for attempt := 1; attempt <= 3; attempt++ {
+		chatResp, err = client.CreateChatCompletion(ctx, req)
+		if err == nil {
+			break
+		}
+		var apiErr *openai.APIError
+		if errors.As(err, &apiErr) && apiErr.HTTPStatusCode >= 500 && apiErr.HTTPStatusCode < 600 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+			continue
+		}
+		return fmt.Errorf("OpenAI request error: %w", err)
+	}
+	if err != nil {
+		return fmt.Errorf("OpenAI request failed after retries: %w", err)
+	}
+
+	// 5 -  Parse JSON safely
+	content := chatResp.Choices[0].Message.Content
+	var info WordInfo
+	if err := json.Unmarshal([]byte(content), &info); err != nil {
+		return fmt.Errorf("invalid JSON in OpenAI response: %w\nraw: %s", err, content)
+	}
+
+	// Capitalize the word
+	info.Word = strings.ToUpper(info.Word[:1]) + info.Word[1:]
+
+	// 6 - Insert into MongoDB
+	coll := svc.mongoDB.Collection("dailywordnewsletter")
+	now := time.Now()
+	doc := bson.M{
+		"newsletterTypeId": newsletterTypeID,
+		"word":             info.Word,
+		"definition":       info.Definition,
+		"usageTip":         info.UsageTip,
+		"funFact":          info.FunFact,
+		"examples":         info.Examples,
+		"synonyms":         info.Synonyms,
+		"antonyms":         info.Antonyms,
+		"createdAt":        now,
+		"sentAt":           nil,
+	}
+	res, err := coll.InsertOne(ctx, doc)
+	if err != nil {
+		return fmt.Errorf("insert newsletter: %w", err)
+	}
+	newsletterID := res.InsertedID.(primitive.ObjectID)
+
+	// 7 - Load recipients
+	recColl := svc.mongoDB.Collection("recipients")
+	cursor, err := recColl.Find(ctx, bson.M{
+		"newsletterTypeId": newsletterTypeID,
+		"subscribed":       true,
+	})
+	if err != nil {
+		return fmt.Errorf("finding recipients: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var recipients []struct {
+		ID    primitive.ObjectID `bson:"_id"`
+		Name  string             `bson:"name"`
+		Email string             `bson:"email"`
+	}
+	if err := cursor.All(ctx, &recipients); err != nil {
+		return fmt.Errorf("decoding recipients: %w", err)
+	}
+
+	if len(recipients) == 0 {
+		return fmt.Errorf("no recipients was found")
+	}
+
+	// 8 - Build and send via SendGrid
+	sgClient := sendgrid.NewSendClient(sendGridKey)
+	from := mail.NewEmail("Cacau says whoooof!", "no.reply@takedi.com")
+	subject := fmt.Sprintf("Learn with Cacau — %s", info.Word)
+
+	m := mail.NewV3Mail()
+	m.SetFrom(from)
+	m.Subject = subject
+	m.AddContent(mail.NewContent("text/plain", getDailyPhrasalVerbNewsletterPlainText(info)))
+	m.AddContent(mail.NewContent("text/html", getDailyPhrasalVerbNewsletterHTML(info)))
+
+	for _, r := range recipients {
+		p := mail.NewPersonalization()
+		p.AddTos(mail.NewEmail(r.Name, r.Email))
+		m.AddPersonalizations(p)
+	}
+
+	respSG, err := sgClient.Send(m)
+	if err != nil {
+		return fmt.Errorf("SendGrid error: %w", err)
+	}
+	if respSG.StatusCode >= 400 {
+		return fmt.Errorf("SendGrid API error: %s", respSG.Body)
+	}
+
+	// 9 - Mark as sent
+	_, err = coll.UpdateByID(ctx, newsletterID, bson.M{"$set": bson.M{"sentAt": time.Now()}})
+	if err != nil {
+		return fmt.Errorf("update newsletter: %w", err)
+	}
+
+	return nil
+}

--- a/api/emails/emails_templates.go
+++ b/api/emails/emails_templates.go
@@ -59,10 +59,10 @@ func getDailyWordNewsletterPlainText(data WordInfo) string {
 
 	var sb strings.Builder
 
-	sb.WriteString("English Daily Pill\n")
+	sb.WriteString("Become smarter with Cacau\n")
 	sb.WriteString(currentDate + "\n\n")
 
-	sb.WriteString("Word of the Day: " + data.Word + "\n\n")
+	sb.WriteString("Phrasal verb of the Day: " + data.Word + "\n\n")
 
 	sb.WriteString("Definition:\n")
 	sb.WriteString(data.Definition + "\n\n")
@@ -85,7 +85,74 @@ func getDailyWordNewsletterPlainText(data WordInfo) string {
 	sb.WriteString("By Vinicius Takedi\n")
 	sb.WriteString("São Paulo, Brazil.\n\n")
 
-	sb.WriteString("You're receiving this email because you subscribed to our Word of the Day newsletter.\n")
+	sb.WriteString("You're receiving this email because you subscribed to our Lern with Cacau newsletter.\n")
+	sb.WriteString("Unsubscribe: {{unsubscribe_link}}\n")
+	sb.WriteString("Update preferences: {{preferences_link}}\n")
+
+	return sb.String()
+}
+
+func getDailyPhrasalVerbNewsletterHTML(data WordInfo) string {
+	currentDate := time.Now().Format("January 2, 2006")
+
+	html := `<!DOCTYPE html><html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="x-apple-disable-message-reformatting"><title>Learning with Cacau - Newsletter</title><!--[if mso]><noscript><xml><o:OfficeDocumentSettings><o:AllowPNG/><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript><![endif]--></head><style>.chat-bubble{position:relative;display:inline-block;margin:0;padding:15px;width:250px;background:#fff;color:#323232;font-size:24px;font-weight:500;font-family:Arial,Helvetica,sans-serif;line-height:1.2;border-radius:50px;position:absolute;top:50%;left:90%;transform:translate(-90%,-50%)}.chat-bubble::after{content:"";position:absolute;top:10px;left:0;border-width:15px 10px 0 10px;border-style:solid;rotate:10deg;border-color:#fff transparent transparent transparent}</style><body style="margin:0;padding:0;width:100%;word-break:break-word;-webkit-font-smoothing:antialiased;background-color:#f4f4f4;font-family:Arial,Helvetica,sans-serif"><div role="article" aria-roledescription="email" lang="en" style="text-size-adjust:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%"><div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:#f4f4f4">Expand your vocabulary with today's featured phrasal verb and its fascinating origins!</div><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin:auto;background-color:#f4f4f4"><tr><td style="padding:20px 0"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="margin:0 auto;background-color:#ffffff;border-radius:8px;box-shadow:0 2px 10px rgba(0,0,0,0.1)"><tr><td style="text-align:center;background-color:#fff;border-radius:8px 8px 0 0"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td style="text-align:center;position:relative"><h1 class="chat-bubble">Today let's learn about the phrasal verb <strong>{{word}}!</strong></h1><img src="https://takedi-portfolio.s3.sa-east-1.amazonaws.com/newsletter/newsletter-daily-word.png" alt="cacau" style="width:100%;height:450px;object-fit:cover;border-radius:8px 8px 0 0"><h1 style="margin:30px 0 0 0;color:#323232;font-size:24px;font-weight:bold;font-family:Arial,Helvetica,sans-serif;line-height:1.2">Learn with Cacau, woof woof!</h1><p style="margin:5px 0 30px 0;color:#323232;font-size:16px;font-family:Arial,Helvetica,sans-serif">{{current_date}}</p></td></tr></table></td></tr><tr><td style="padding:20px 20px 15px 20px;text-align:center;background-color:#68a5d438"><h2 style="margin:0 0 10px 0;color:#0D0D0D;font-size:24px;font-weight:bold;font-family:Arial,Helvetica,sans-serif;line-height:1.1">Our phrasal verb for today is {{word}}</h2></td></tr><tr><td style="padding:0 40px 20px 40px"><h3 style="margin:30px 0 15px 0;color:#0D0D0D;font-size:18px;font-weight:bold;font-family:Arial,Helvetica,sans-serif">Definition</h3><p style="margin:0 0 20px 0;color:#555555;font-size:16px;line-height:1.6;font-family:Arial,Helvetica,sans-serif">{{definition}}</p><div style="background-color:#68A5D4;border-left:4px solid #235888;padding:15px 20px;margin:25px 0;border-radius:0 4px 4px 0"><p style="margin:0;color:#fff;font-size:16px;font-family:Arial,Helvetica,sans-serif"><strong>Did you know?</strong> {{funFact}}</p></div></td></tr><tr><td style="padding:0 40px 30px 40px"><h3 style="margin:0 0 15px 0;color:#333333;font-size:18px;font-weight:bold;font-family:Arial,Helvetica,sans-serif">Example Sentences</h3>{{examples}}</td></tr><tr><td style="padding:0 40px 20px 40px;margin:50px 0 0 0"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td style="width:50%;vertical-align:top;padding-right:15px;margin:50px 0 0 0"><h4 style="margin:0 0 10px 0;color:#333333;font-size:18px;font-weight:bold;font-family:Arial,Helvetica,sans-serif">Synonyms</h4><p style="margin:0;color:#555555;font-size:16px;line-height:1.5;font-family:Arial,Helvetica,sans-serif">{{synonyms}}</p></td><td style="width:50%;vertical-align:top;padding-left:15px"><h4 style="margin:0 0 10px 0;color:#333333;font-size:18px;font-weight:bold;font-family:Arial,Helvetica,sans-serif">Antonyms</h4><p style="margin:0;color:#555555;font-size:16px;line-height:1.5;font-family:Arial,Helvetica,sans-serif">{{antonyms}}</p></td></tr></table><div style="background-color:#68A5D4;border-left:4px solid #235888;padding:15px 20px;margin:30px 0;border-radius:0 4px 4px 0"><p style="margin:0;color:#fff;font-size:16px;font-family:Arial,Helvetica,sans-serif"><strong>Usage Tip:</strong> {{usageTip}}</p></div></td></tr><tr><td style="padding:30px 40px;background-color:#f8f9fa;border-top:1px solid #e9ecef"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td style="text-align:center"><p style="margin:0 0 15px 0;color:#888888;font-size:12px;font-family:Arial,Helvetica,sans-serif">By Vinicius Takedi<br> São Paulo, Brazil.</p><p style="margin:0;color:#888888;font-size:11px;font-family:Arial,Helvetica,sans-serif">You're receiving this email because you subscribed to our Learn with Cacau newsletter.<br><a href="{{unsubscribe_link}}" style="color:#888888;text-decoration:underline">Unsubscribe</a> | <a href="{{preferences_link}}" style="color:#888888;text-decoration:underline">Update preferences</a></p></td></tr></table></td></tr></table></td></tr></table></div></body></html>`
+	html = strings.Replace(html, "{{current_date}}", currentDate, -1)
+	html = strings.Replace(html, "{{word}}", data.Word, -1)
+	html = strings.Replace(html, "{{definition}}", data.Definition, -1)
+	html = strings.Replace(html, "{{funFact}}", data.FunFact, -1)
+	html = strings.Replace(html, "{{usageTip}}", data.UsageTip, -1)
+
+	var exBuilder strings.Builder
+	for _, ex := range data.Examples {
+		exBuilder.WriteString(`<div style="margin-bottom: 15px;">`)
+		exBuilder.WriteString("\n<p style=\"margin: 0; color: #555555; font-size: 18px; line-height: 1.6; font-family: Arial, Helvetica, sans-serif;\">")
+		exBuilder.WriteString(ex)
+		exBuilder.WriteString("</p>\n</div>\n")
+	}
+	html = strings.Replace(html, "{{examples}}", exBuilder.String(), -1)
+
+	html = strings.Replace(html, "{{synonyms}}", strings.Join(data.Synonyms, ", "), -1)
+	html = strings.Replace(html, "{{antonyms}}", strings.Join(data.Antonyms, ", "), -1)
+
+	return html
+}
+
+func getDailyPhrasalVerbNewsletterPlainText(data WordInfo) string {
+	loc, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		loc = time.Local
+	}
+	currentDate := time.Now().In(loc).Format("January 2, 2006")
+
+	var sb strings.Builder
+
+	sb.WriteString("Become smarter with Cacau\n")
+	sb.WriteString(currentDate + "\n\n")
+
+	sb.WriteString("Phrasal verb of the Day: " + data.Word + "\n\n")
+
+	sb.WriteString("Definition:\n")
+	sb.WriteString(data.Definition + "\n\n")
+
+	sb.WriteString("Did you know?\n")
+	sb.WriteString(data.FunFact + "\n\n")
+
+	sb.WriteString("Examples:\n")
+	for _, ex := range data.Examples {
+		sb.WriteString("- " + ex + "\n")
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("Synonyms: " + strings.Join(data.Synonyms, ", ") + "\n")
+	sb.WriteString("Antonyms: " + strings.Join(data.Antonyms, ", ") + "\n\n")
+
+	sb.WriteString("Usage Tip:\n")
+	sb.WriteString(data.UsageTip + "\n\n")
+
+	sb.WriteString("By Vinicius Takedi\n")
+	sb.WriteString("São Paulo, Brazil.\n\n")
+
+	sb.WriteString("You're receiving this email because you subscribed to our Lern with Cacau newsletter.\n")
 	sb.WriteString("Unsubscribe: {{unsubscribe_link}}\n")
 	sb.WriteString("Update preferences: {{preferences_link}}\n")
 

--- a/cron/crons.go
+++ b/cron/crons.go
@@ -4,5 +4,6 @@ import newslettercron "portfolio/api/cron/newsletters"
 
 func Init() {
 	newslettercron.SendDailyWord()
+	newslettercron.SendDailyPhrasalVerb()
 	// Add more cron jobs here as needed
 }

--- a/cron/newsletters/daily_phrasal_verb.go
+++ b/cron/newsletters/daily_phrasal_verb.go
@@ -8,7 +8,7 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-func SendDailyWord() {
+func SendDailyPhrasalVerb() {
 	// Determine GMT-3 (São Paulo) location
 	loc, err := time.LoadLocation("America/Sao_Paulo")
 	if err != nil {
@@ -27,24 +27,24 @@ func SendDailyWord() {
 	// TODO: Get schedule time from Database
 	// Schedule at 07:07:00 every day
 	spec := "0 7 7 * * *"
-	_, err = c.AddFunc(spec, func() {
+	id, err := c.AddFunc(spec, func() {
 		weekday := time.Now().In(loc).Weekday()
-		if weekday != time.Monday && weekday != time.Wednesday && weekday != time.Friday && weekday != time.Sunday {
+		if weekday != time.Tuesday && weekday != time.Thursday && weekday != time.Saturday {
 			return
 		}
 
 		now := time.Now().In(loc).Format("2006-01-02T15:04:05")
-		if err := emailsController.SendDailyWordNewsletter(); err != nil {
-			fmt.Println(now, "- Error sending daily English word:", err)
+		if err := emailsController.SendDailyPhrasalVerbNewsletter(); err != nil {
+			fmt.Println(now, "- Error sending daily English word - Phasal Verb Edition:", err)
 			return
 		}
 		fmt.Println(now, "- OK, Daily word sent !")
 	})
 	if err != nil {
-		panic(fmt.Sprintf("scheduling daily word newsletter: %v", err))
+		panic(fmt.Sprintf("scheduling daily word newsletter - Phrasal verb edition: %v", err))
 	}
 
-	// c.Entry(id).Job.Run()
+	c.Entry(id).Job.Run()
 
 	go c.Start()
 }

--- a/cron/newsletters/daily_phrasal_verb.go
+++ b/cron/newsletters/daily_phrasal_verb.go
@@ -15,7 +15,7 @@ func SendDailyPhrasalVerb() {
 		loc = time.FixedZone("GMT-3", -3*3600)
 	}
 
-	fmt.Println(time.Now().In(loc).Format("2006-01-02T15:04:05"), "- Cron to send the daily English word")
+	fmt.Println(time.Now().In(loc).Format("2006-01-02T15:04:05"), "- Cron to send the daily English word - Phrasal Verb Edition")
 	emailsController := emails.MakeEmailsController()
 
 	// Create a cron with seconds and the right TZ
@@ -24,12 +24,19 @@ func SendDailyPhrasalVerb() {
 		cron.WithLocation(loc),
 	)
 
+	allowedWeekdays := map[time.Weekday]bool{
+		time.Tuesday:  true,
+		time.Thursday: true,
+		time.Saturday: true,
+	}
+
 	// TODO: Get schedule time from Database
 	// Schedule at 07:07:00 every day
 	spec := "0 7 7 * * *"
 	id, err := c.AddFunc(spec, func() {
 		weekday := time.Now().In(loc).Weekday()
-		if weekday != time.Tuesday && weekday != time.Thursday && weekday != time.Saturday {
+
+		if !allowedWeekdays[weekday] {
 			return
 		}
 
@@ -41,7 +48,7 @@ func SendDailyPhrasalVerb() {
 		fmt.Println(now, "- OK, Daily word sent !")
 	})
 	if err != nil {
-		panic(fmt.Sprintf("scheduling daily word newsletter - Phrasal verb edition: %v", err))
+		panic(fmt.Sprintf("scheduling learn with Cacau newsletter - Phrasal verb edition: %v", err))
 	}
 
 	c.Entry(id).Job.Run()

--- a/cron/newsletters/daily_word.go
+++ b/cron/newsletters/daily_word.go
@@ -15,7 +15,7 @@ func SendDailyWord() {
 		loc = time.FixedZone("GMT-3", -3*3600)
 	}
 
-	fmt.Println(time.Now().In(loc).Format("2006-01-02T15:04:05"), "- Cron to send the daily English word")
+	fmt.Println(time.Now().In(loc).Format("2006-01-02T15:04:05"), "- Cron to send the daily English word - Word Edition")
 	emailsController := emails.MakeEmailsController()
 
 	// Create a cron with seconds and the right TZ
@@ -24,12 +24,20 @@ func SendDailyWord() {
 		cron.WithLocation(loc),
 	)
 
+	allowedWeekdays := map[time.Weekday]bool{
+		time.Monday:    true,
+		time.Wednesday: true,
+		time.Friday:    true,
+		time.Sunday:    true,
+	}
+
 	// TODO: Get schedule time from Database
 	// Schedule at 07:07:00 every day
 	spec := "0 7 7 * * *"
 	_, err = c.AddFunc(spec, func() {
 		weekday := time.Now().In(loc).Weekday()
-		if weekday != time.Monday && weekday != time.Wednesday && weekday != time.Friday && weekday != time.Sunday {
+
+		if !allowedWeekdays[weekday] {
 			return
 		}
 


### PR DESCRIPTION
# 🚀 Add Phrasal Verb Newsletter Feature

**Short description of the change.**

## 📖 Description

- **What’s changing?**  
  Implemented functionality to send a new type of newsletter: the Daily Phrasal Verb Newsletter. This includes changes to the email service and the introduction of new cron jobs for scheduling the newsletter dispatch.

- **Why?**  
  To enhance the existing newsletter service by adding diverse content and targeting English learners interested in expanding their knowledge of phrasal verbs.

## 🛠 Implementation Details

- **Emails Controller:**  
  - Introduced `SendDailyPhrasalVerbNewsletter` method in the `EmailsController` that uses a new service method to gather content and dispatch emails.
  
- **Emails Service:**  
  - Added `SendDailyPhrasalVerbNewsletter` method to handle content generation via OpenAI, recipient selection, and email distribution using SendGrid.
  - Utilized MongoDB operations to manage newsletter types and recipient records.
  - Implemented OpenAI API calls with retry logic for robust interaction.
  
- **Email Templates:**  
  - Created HTML and plain text templates specifically for the Phrasal Verb newsletters.
  
- **Cron Jobs:**  
  - Configured a new cron job `SendDailyPhrasalVerb` to schedule newsletter dispatch on specific days.

## 📊 Queries changed

- Queries modified to handle fetching unused words for the phrasal verb newsletter and updating recipient selections based on newsletter type IDs in MongoDB.

## ⚙️ New envs

- None, but relied on existing `OPENAI_API_KEY` and `SENDGRID_API_KEY` environment variables.

## 🔗 Related Issues / Tickets

- None reported currently; this is a feature addition to enhance functionality.