### PR TITLE
Feat: Close mongo connection when API down

### DIFF
--- a/api/jobs/jobs_service.go
+++ b/api/jobs/jobs_service.go
@@ -26,6 +26,7 @@ func (ctx *JobsService) GetAll() ([]JobsDB, error) {
 	if err != nil {
 		return []JobsDB{}, err
 	}
+
 	defer jobsDb.Close(ctxBg)
 
 	var jobs []JobsDB

--- a/infra/db/mongodb.go
+++ b/infra/db/mongodb.go
@@ -36,6 +36,19 @@ func InitMongoDB() error {
 	return nil
 }
 
+func KillMongoDB() error {
+	if database.Client() == nil {
+		return fmt.Errorf("mongodb client didn't initialized")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := database.Client().Disconnect(ctx); err != nil {
+		return fmt.Errorf("disconnect mongodb: %w", err)
+	}
+	return nil
+}
+
 func GetMongoDB() *mongo.Database {
 	return database
 }

--- a/main.go
+++ b/main.go
@@ -30,9 +30,11 @@ func main() {
 	config.Init(*environment)
 
 	if err := db.InitMongoDB(); err != nil {
-		log.Fatalf("Error to init mongodb client: ", err.Error())
+		log.Fatalf("error to init mongodb client: %s", err.Error())
 		os.Exit(1)
 	}
+
+	defer db.KillMongoDB()
 
 	// Initialize the cron jobs
 	// This will run the cron jobs in a separate goroutine

--- a/router/router.go
+++ b/router/router.go
@@ -22,6 +22,7 @@ func NewRouter(environment string) *gin.Engine {
 
 		originsAllowed := []string{
 			"https://takedi.com",
+			"https://www.takedi.com",
 			"https://my-portfolio-git-v2-viniciustakedis-projects.vercel.app",
 		}
 


### PR DESCRIPTION
# 🚀 Close mongo connection when API down

## 📖 Description
- **What’s changing?**  
  Several improvements and changes have been made to the codebase: a new function to close the MongoDB connection, renaming of a file for consistency, and updates to allow additional domain support.

- **Why?**  
  The motivation behind this PR includes enhancements for better resource management (ensuring MongoDB connections are properly closed), improving code readability (file rename), and extending CORS configuration to support additional domains.

## 🛠 Implementation Details

- Bullet out the key technical changes:
  - Added `KillMongoDB` function to close the MongoDB client connection properly, preventing potential resource leaks.
  - Renamed file `mongo_db.go` to `mongodb.go` for consistency with naming conventions.
  - Updated error logging format in `main.go` for consistency.
  - Included a defer call to `KillMongoDB()` in `main.go` to ensure the MongoDB client disconnects when the application exits.
  - Extended CORS settings in `router.go` to support an additional domain: `https://www.takedi.com`.

## 📊 Queries changed
- None

## ⚙️ New envs
- None

## 🔗 Related Issues / Tickets
- None